### PR TITLE
Add EFFECTIVE_ABORT runtime option

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ several runtime options that can be set via environment variables:
 * `EFFECTIVE_NOLOG=1`: Do not print the log altogether (default off).
 * `EFFECTIVE_SINGLETHREADED=1`: Assume the program is single-threaded
    (default off).
+* `EFFECTIVE_ABORT=1`: Crash the program after printing the error report.
 * `EFFECTIVE_MAXERRS=N`: Abort the program after `N` errors
    (default `SIZE_MAX`).
 * `EFFECTIVE_VERBOSITY=(0|1|2|9)`: Set error verbosity level, where higher

--- a/llvm-4.0.1.src/projects/compiler-rt/lib/effective/effective_log.c
+++ b/llvm-4.0.1.src/projects/compiler-rt/lib/effective/effective_log.c
@@ -946,7 +946,7 @@ static EFFECTIVE_DESTRUCTOR(12399) void effective_report(void)
     fprintf(stderr, "--------------------------------------------------\n");
     fflush(stderr);
 
-    if (effective_abort)
+    if (effective_abort && EFFECTIVE_ERROR_TABLE_NUM_ENTRIES)
       abort();
 }
 

--- a/llvm-4.0.1.src/projects/compiler-rt/lib/effective/effective_log.c
+++ b/llvm-4.0.1.src/projects/compiler-rt/lib/effective/effective_log.c
@@ -277,6 +277,7 @@ size_t effective_num_bad_free_errors = 0;
 static bool effective_no_trace = false;
 static bool effective_no_log = false;
 static bool effective_single_threaded = false;
+static bool effective_abort = false;
 static size_t effective_max_errs = SIZE_MAX;
 
 /*
@@ -525,9 +526,9 @@ void effective_bounds_error(EFFECTIVE_BOUNDS bounds, const void *ptr,
     base = (const void *)(meta + 1);
     ssize_t lb = (bounds[0] - (intptr_t)base);
     ssize_t ub = (bounds[1] - (intptr_t)base);
-    
+
     uint64_t hval = EFFECTIVE_BOUNDS_HASH(t->hash2, lb, ub);
-    
+
     EFFECTIVE_ERROR *error = effective_insert_error(hval);
     if (error == NULL)
         return;
@@ -944,6 +945,9 @@ static EFFECTIVE_DESTRUCTOR(12399) void effective_report(void)
     }
     fprintf(stderr, "--------------------------------------------------\n");
     fflush(stderr);
+
+    if (effective_abort)
+      abort();
 }
 
 /*
@@ -983,6 +987,8 @@ static EFFECTIVE_CONSTRUCTOR(17777) void effective_log_init(void)
         effective_no_log = true;
     if (getenv("EFFECTIVE_SINGLETHREADED") != NULL)
         effective_single_threaded = true;
+    if (getenv("EFFECTIVE_ABORT") != NULL)
+        effective_abort = true;
     const char *max = getenv("EFFECTIVE_MAXERRS");
     size_t tmp;
     if (max != NULL && sscanf(max, "%zu", &tmp) == 1)
@@ -1098,7 +1104,7 @@ static EFFECTIVE_NOINLINE void effective_write_type(EFFECTIVE_STREAM *stream,
     }
     else
         effective_write_string(stream, info->name);
-    
+        
     bool is_anon = false;
     if (strcmp(info->name, "struct ") == 0)
         is_anon = true;
@@ -1353,4 +1359,3 @@ static EFFECTIVE_NOINLINE EFFECTIVE_NORETURN void effective_error(
     va_end(ap);
     abort();
 }
-


### PR DESCRIPTION
## What?

Add `EFFECTIVE_ABORT` runtime option, behaving like the sanitizer's common flag `abort_on_error` ([link to the documentation](https://github.com/google/sanitizers/wiki/SanitizerCommonFlags)), which explicitly crashes the execution if at least one error is found.

## Why?

To automatically check if an EffectiveSan error happened during the execution by checking the deadly signal flag in the program's exit status.

## How?

- Add the runtime option `EFFECTIVE_ABORT`,
- set `effective_abort=true` if the option has been given (following EffectiveSan runtime option management in `effective_log_init`),
- in `effective_report`, calls `abort()` if the option is enabled and at least one error has been detected by EffectiveSan (using `EFFECTIVE_ERROR_TABLE_NUM_ENTRIES`).


## Testing?
- The code passes the tests in Test.cpp
- For Example.cpp:
  - `./Example` returns the exit code 0
  - `EFFECTIVE_ABORT=1 ./Example` returns the exit code 134
- For a code without error (I used Example.cpp without the erroneous instructions):
  - `./Example` and `EFFECTIVE_ABORT=1 ./Example` returns the exit code 0

## Anything Else?
- Documentation updated with the `EFFECTIVE_ABORT` option into the runtime option list

Best