### PR TITLE
Fixing the compilation backend type uncompatible vector size

### DIFF
--- a/llvm-4.0.1.src/lib/Transforms/Instrumentation/EffectiveSan.cpp
+++ b/llvm-4.0.1.src/lib/Transforms/Instrumentation/EffectiveSan.cpp
@@ -3018,9 +3018,9 @@ static const BoundsEntry &calculateBounds(llvm::Module &M, llvm::Function &F,
         {
             auto *GEPOp = llvm::dyn_cast<llvm::GEPOperator>(CE);
             InsertPoint IP = nextInsertPoint(F, Ptr);
-            auto [Bounds1, lb1, ub1] = calculateBoundsGEP(M, F, GEPOp, IP,
+            BoundsEntry Entry = calculateBoundsGEP(M, F, GEPOp, IP,
                 tInfo, cInfo, bInfo);
-            Bounds = Bounds1; lb = lb1; ub = ub1;
+            Bounds = Entry.Bounds; lb = Entry.lb; ub = Entry.ub;
             break;
         }
         case llvm::Instruction::BitCast:
@@ -3105,9 +3105,9 @@ static const BoundsEntry &calculateBounds(llvm::Module &M, llvm::Function &F,
     {
         auto *GEPOp = llvm::dyn_cast<llvm::GEPOperator>(GEP);
         InsertPoint IP = nextInsertPoint(F, Ptr);
-        auto [Bounds1, lb1, ub1] = calculateBoundsGEP(M, F, GEPOp, IP, tInfo,
+        BoundsEntry Entry = calculateBoundsGEP(M, F, GEPOp, IP, tInfo,
             cInfo, bInfo);
-        Bounds = Bounds1; lb = lb1; ub = ub1;
+        Bounds = Entry.Bounds; lb = Entry.lb; ub = Entry.ub;
     }
     else if (auto *Cast = llvm::dyn_cast<llvm::BitCastInst>(Ptr))
     {
@@ -4402,7 +4402,8 @@ struct EffectiveSan : public llvm::ModulePass
             llvm::ConstantInt::get(llvm::Type::getInt64Ty(Cxt), 0)}));
         EmptyEntry = llvm::ConstantStruct::get(EntryTy, Elems);
         ObjMetaTy = llvm::StructType::get(Cxt, /*isPacked=*/true);
-        ObjMetaTy->setName("EFFECTIVE_META");
+	if (!ObjMetaTyy->isLiteral())
+            ObjMetaTy->setName("EFFECTIVE_META");
         Fields.clear();
         Fields.push_back(TypeTy->getPointerTo());           /* type */
         Fields.push_back(llvm::Type::getInt64Ty(Cxt));      /* size */

--- a/llvm-4.0.1.src/projects/compiler-rt/lib/effective/effective.c
+++ b/llvm-4.0.1.src/projects/compiler-rt/lib/effective/effective.c
@@ -41,7 +41,7 @@ EFFECTIVE_BOUNDS effective_bounds_narrow(EFFECTIVE_BOUNDS bounds1,
     EFFECTIVE_BOUNDS cmp = (bounds1 > bounds2);
     cmp ^= EFFECTIVE_BOUNDS_NEG_1_0;
     EFFECTIVE_BOUNDS bounds3 =
-        __builtin_ia32_pblendvb128(bounds1, bounds2, cmp);
+	__builtin_ia32_pblendvb128((EFFECTIVE_BOUNDS2)bounds1, (EFFECTIVE_BOUNDS2)bounds2, (EFFECTIVE_BOUNDS2)cmp);
     return bounds3;
 }
 
@@ -236,7 +236,7 @@ EFFECTIVE_HOT void effective_bounds_check(EFFECTIVE_BOUNDS bounds0,
     EFFECTIVE_BOUNDS sizes = {lb+1, ub};
     EFFECTIVE_BOUNDS bounds = bounds0 - sizes;
     EFFECTIVE_BOUNDS cmp = (ptrs > bounds);
-    int mask = __builtin_ia32_pmovmskb128(cmp);
+    int mask = __builtin_ia32_pmovmskb128((EFFECTIVE_BOUNDS2)cmp);
     if (EFFECTIVE_UNLIKELY(mask != 0x00FF))
     {
         size_t size = sizes[1] - sizes[0] + 1;


### PR DESCRIPTION
Fix1: Error: incompatible type for argument 1 of ‘__builtin_ia32_pblendvb128’
        Note:expected ‘__vector(16) char’ but argument is of type ‘EFFECTIVE_BOUNDS {aka __vector(2) long int}’
Fix2: Error when parse : auto [Bounds1, lb1, ub1] = calculateBoundsGEP(...)